### PR TITLE
Fix error fmt.Errorf call has more than one error-wrapping directive %w

### DIFF
--- a/internal/controllers/errors.go
+++ b/internal/controllers/errors.go
@@ -24,7 +24,7 @@ func NewErrorResponse(msg string) *ErrorResponse {
 }
 
 // SetErrorResponse will attempt to parse the given error
-// and set the response status code and message using the ResponseWriter
+// and set the response status code and using the ResponseWriter
 // according to the type of the error.
 func SetErrorResponse(w http.ResponseWriter, err error) {
 	if err == nil {

--- a/internal/controllers/instream.go
+++ b/internal/controllers/instream.go
@@ -31,7 +31,7 @@ func (h *Handler) InStream(w http.ResponseWriter, r *http.Request) {
 	// Parsing the Multipart file
 	_, hd, err := r.FormFile("file")
 	if err != nil {
-		e := fmt.Errorf("%w: %w", ErrFormFile, err)
+		e := fmt.Errorf("%w: %v", ErrFormFile, err)
 		h.Logger.Debug().Str("req_id", req_id.String()).Msgf("%v", e)
 
 		SetErrorResponse(w, e)
@@ -40,7 +40,7 @@ func (h *Handler) InStream(w http.ResponseWriter, r *http.Request) {
 
 	f, err := hd.Open()
 	if err != nil {
-		e := fmt.Errorf("%w: %w", ErrOpenFileHeaders, err)
+		e := fmt.Errorf("%w: %v", ErrOpenFileHeaders, err)
 		h.Logger.Debug().Str("req_id", req_id.String()).Msgf("%v", e)
 
 		SetErrorResponse(w, e)


### PR DESCRIPTION
Fix error `fmt.Errorf call has more than one error-wrapping directive %w` for go < 1.20