### PR TITLE
Fix an issue when the file being scanned is too big, clamav would ans…

### DIFF
--- a/internal/clamav/clamav.go
+++ b/internal/clamav/clamav.go
@@ -199,6 +199,13 @@ func (c *ClamavClient) InStream(ctx context.Context, r io.Reader, size int64) ([
 		if e != nil {
 			return nil, fmt.Errorf("error while streaming content to %s/%s: %w", c.network, c.address, err)
 		}
+		err = c.parseResponse(resp)
+		if err != nil {
+			if err == ErrScanFileSizeLimitExceeded {
+				return nil, err
+			}
+			return nil, fmt.Errorf("error from clamav: %w", err)
+		}
 		return resp, fmt.Errorf("error while streaming content to %s/%s: %w", c.network, c.address, err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -9,6 +9,8 @@ import (
 	"syscall"
 	"time"
 
+	_ "net/http/pprof" // Register the pprof handlers
+
 	"github.com/gorilla/handlers"
 	"github.com/julienschmidt/httprouter"
 	"github.com/justinas/alice"
@@ -18,6 +20,12 @@ import (
 	"github.com/lescactus/clamav-api-go/internal/logger"
 	"github.com/rs/zerolog/hlog"
 )
+
+func init() {
+	go func() {
+		log.Println(http.ListenAndServe("localhost:6060", nil))
+	}()
+}
 
 func main() {
 	// Get application configuration


### PR DESCRIPTION
…wer with "size limit exceeded" but we would andwer with a generic error message to the client